### PR TITLE
feat(a2a): WebSocket hub and REST route for agent-to-agent messaging

### DIFF
--- a/services/orchestrator/app/api/a2a.py
+++ b/services/orchestrator/app/api/a2a.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from ..core.hub import hub
+
+router = APIRouter()
+
+
+class RouteMessage(BaseModel):
+    sender: str
+    recipient: str
+    data: dict | str
+
+
+@router.post("/route")
+async def route_message(msg: RouteMessage):
+    if msg.recipient not in hub.connections:
+        raise HTTPException(status_code=404, detail=f"{msg.recipient} not connected")
+    await hub.send(msg.recipient, {"from": msg.sender, "data": msg.data})
+    return {"success": True}
+

--- a/services/orchestrator/app/core/hub.py
+++ b/services/orchestrator/app/core/hub.py
@@ -1,0 +1,24 @@
+from fastapi import WebSocket
+from typing import Dict
+
+
+class Hub:
+    def __init__(self):
+        self.connections: Dict[str, WebSocket] = {}
+
+    async def register(self, agent_id: str, ws: WebSocket):
+        await ws.accept()
+        self.connections[agent_id] = ws
+
+    def unregister(self, agent_id: str):
+        self.connections.pop(agent_id, None)
+
+    async def send(self, agent_id: str, message: dict):
+        ws = self.connections.get(agent_id)
+        if ws:
+            await ws.send_json(message)
+
+
+# single shared hub instance
+hub = Hub()
+

--- a/services/orchestrator/examples/agent_a.py
+++ b/services/orchestrator/examples/agent_a.py
@@ -1,0 +1,17 @@
+import asyncio
+import websockets
+import json
+
+
+async def main():
+    uri = "ws://localhost:8000/ws/agents/agentA"
+    async with websockets.connect(uri) as websocket:
+        # Send a message to agentB
+        await websocket.send(json.dumps({"to": "agentB", "data": {"message": "hello from A"}}))
+        # Listen for reply
+        reply = await websocket.recv()
+        print("AgentA received:", reply)
+
+
+asyncio.run(main())
+

--- a/services/orchestrator/examples/agent_b.py
+++ b/services/orchestrator/examples/agent_b.py
@@ -1,0 +1,18 @@
+import asyncio
+import websockets
+import json
+
+
+async def main():
+    uri = "ws://localhost:8000/ws/agents/agentB"
+    async with websockets.connect(uri) as websocket:
+        while True:
+            msg = json.loads(await websocket.recv())
+            print("AgentB received:", msg)
+            # Reply if message came from agentA
+            if msg.get("from") == "agentA":
+                await websocket.send(json.dumps({"to": "agentA", "data": {"reply": "hi from B"}}))
+
+
+asyncio.run(main())
+


### PR DESCRIPTION
This PR adds an agent-to-agent (A2A) messaging hub and route to the orchestrator.

What's included
- `app/core/hub.py`: shared Hub with register/unregister/send and connection store
- `app/api/a2a.py`: REST endpoint `POST /route` to send to connected agents
- `app/main.py`: WebSocket endpoint `/ws/agents/{agent_id}` now uses the shared hub; mounts A2A router
- Examples: `examples/agent_a.py` and `examples/agent_b.py` using `websockets`

How to test locally
1. Run the backend (e.g., `uvicorn services.orchestrator.app.main:app --reload`)
2. In two terminals, run:
   - `python services/orchestrator/examples/agent_b.py`
   - `python services/orchestrator/examples/agent_a.py`
3. Observe AgentA <-> AgentB message exchange over the hub.

Also available: send via REST
- `POST /route` with `{ "sender": "agentA", "recipient": "agentB", "data": {"hello": "world"} }` to push a message to any connected agent.