### PR TITLE
chore(orchestrator): Makefile + WebSocket smoke script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ python services/orchestrator/examples/agent_a.py
 
 If you use Python 3.13, installing pydantic-core may fail due to PyO3 constraints; use Python 3.12.
 
+### Makefile helpers
+
+From `services/orchestrator`, common tasks are available via Makefile:
+
+```
+# Create venv (prefers python3.12 if available) and install deps
+make install
+
+# Run dev server (uvicorn --reload)
+make dev
+
+# Lint and tests
+make lint
+make test
+
+# WebSocket smoke test (starts uvicorn, runs A↔B exchange)
+make smoke
+```
+
 ## Frontend (apps/web)
 
 A minimal Next.js 14 app with TypeScript and ESLint lives in `apps/web`. It includes a simple status widget that pings your backend's `/health` endpoint.

--- a/services/orchestrator/Makefile
+++ b/services/orchestrator/Makefile
@@ -1,0 +1,41 @@
+ROOT := $(abspath $(CURDIR)/../..)
+VENV := $(ROOT)/.venv
+
+.PHONY: venv install dev lint test smoke stop
+
+venv:
+	@if command -v python3.12 >/dev/null 2>&1; then \
+		PY=python3.12; \
+	else \
+		PY=python3; \
+	fi; \
+	$$PY -m venv $(VENV)
+
+install: venv
+	. $(VENV)/bin/activate; \
+	pip install -U pip; \
+	pip install -r services/orchestrator/requirements.txt; \
+	pip install ruff pytest
+
+dev:
+	cd $(ROOT); . $(VENV)/bin/activate; \
+	uvicorn services.orchestrator.app.main:app --reload
+
+lint:
+	cd $(ROOT); . $(VENV)/bin/activate; \
+	ruff check services/orchestrator
+
+test:
+	cd $(ROOT); . $(VENV)/bin/activate; \
+	pytest -q services/orchestrator
+
+smoke:
+	cd $(ROOT); . $(VENV)/bin/activate; \
+	( python -m uvicorn services.orchestrator.app.main:app --port 8000 --log-level warning & echo $$! > uvicorn.pid ); \
+	sleep 1; \
+	python services/orchestrator/scripts/smoke_ws.py; \
+	kill `cat uvicorn.pid` || true; rm -f uvicorn.pid
+
+stop:
+	@kill `cat uvicorn.pid` 2>/dev/null || true; rm -f uvicorn.pid || true
+

--- a/services/orchestrator/scripts/smoke_ws.py
+++ b/services/orchestrator/scripts/smoke_ws.py
@@ -1,0 +1,41 @@
+import asyncio
+import json
+import os
+
+import websockets
+
+
+def _ws_url(agent_id: str) -> str:
+    host = os.environ.get("SMOKE_HOST", "127.0.0.1")
+    port = int(os.environ.get("SMOKE_PORT", "8000"))
+    return f"ws://{host}:{port}/ws/agents/{agent_id}"
+
+
+async def run() -> None:
+    a_uri = _ws_url("agentA")
+    b_uri = _ws_url("agentB")
+
+    async with websockets.connect(b_uri) as wb:
+        received = {}
+
+        async def recv_b():
+            received["msg"] = await wb.recv()
+
+        task = asyncio.create_task(recv_b())
+        async with websockets.connect(a_uri) as wa:
+            await wa.send(json.dumps({"to": "agentB", "data": {"ping": "hello"}}))
+            await asyncio.sleep(0.3)
+            assert "msg" in received, "agentB did not receive from agentA"
+            data = json.loads(received["msg"])  # type: ignore[index]
+            assert data.get("from") == "agentA", data
+            await wb.send(json.dumps({"to": "agentA", "data": {"pong": "hi"}}))
+            reply = await wa.recv()
+            print("WS A<->B reply:", reply)
+            r = json.loads(reply)
+            assert r.get("from") == "agentB", r
+            assert r.get("data", {}).get("pong") == "hi", r
+
+
+if __name__ == "__main__":
+    asyncio.run(run())
+


### PR DESCRIPTION
Developer experience improvements for the orchestrator.

- Makefile in `services/orchestrator` with targets: `install`, `dev`, `lint`, `test`, `smoke`, `stop`
- `scripts/smoke_ws.py`: minimal A↔B WebSocket exchange test using `websockets`
- README: usage notes for Makefile targets

Usage:
```
cd services/orchestrator
make install    # creates venv (prefers py3.12), installs deps
make dev        # uvicorn --reload
make smoke      # starts uvicorn, runs A↔B test, shuts down
```