### PR TITLE
feat(web): proxy /api/health to backend and use it in status widget

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,19 @@
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const base = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+  try {
+    const res = await fetch(`${base}/health`, { cache: 'no-store' });
+    const data = await res.json().catch(() => ({ status: 'error' }));
+    return new Response(JSON.stringify(data), {
+      status: res.ok ? 200 : res.status,
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch {
+    return new Response(JSON.stringify({ status: 'offline' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}
+

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,8 +6,7 @@ export default function Page() {
   const [status, setStatus] = useState<'unknown' | 'online' | 'offline'>('unknown');
 
   useEffect(() => {
-    const base = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
-    fetch(`${base}/health`)
+    fetch(`/api/health`)
       .then((r) => (r.ok ? setStatus('online') : setStatus('offline')))
       .catch(() => setStatus('offline'));
   }, []);
@@ -41,4 +40,3 @@ export default function Page() {
     </main>
   );
 }
-


### PR DESCRIPTION
This adds a Next.js App Router API route that proxies the orchestrator's `/health` to avoid CORS and env drift.

- New: `app/api/health/route.ts` (server route, no-store, dynamic)
- Update: homepage fetches `/api/health` instead of hitting the backend directly

Config: still honors `NEXT_PUBLIC_API_URL` for the backend base URL.