### PR TITLE
chore(orchestrator): clarify WS var and widen typing for a2a

### DIFF
--- a/services/orchestrator/app/api/a2a.py
+++ b/services/orchestrator/app/api/a2a.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from typing import Union
 from ..core.hub import hub
 
 router = APIRouter()
@@ -8,7 +9,7 @@ router = APIRouter()
 class RouteMessage(BaseModel):
     sender: str
     recipient: str
-    data: dict | str
+    data: Union[dict, str]
 
 
 @router.post("/route")
@@ -17,4 +18,3 @@ async def route_message(msg: RouteMessage):
         raise HTTPException(status_code=404, detail=f"{msg.recipient} not connected")
     await hub.send(msg.recipient, {"from": msg.sender, "data": msg.data})
     return {"success": True}
-

--- a/services/orchestrator/app/main.py
+++ b/services/orchestrator/app/main.py
@@ -22,10 +22,10 @@ async def agent_socket(ws: WebSocket, agent_id: str):
     try:
         while True:
             data = await ws.receive_json()
-            to = data.get("to")
-            if to:
+            recipient = data.get("to")
+            if recipient:
                 # Relay the message to the intended recipient
-                await hub.send(to, {"from": agent_id, "data": data.get("data")})
+                await hub.send(recipient, {"from": agent_id, "data": data.get("data")})
             else:
                 # Acknowledge receipt if no target
                 await ws.send_json({"ack": True})


### PR DESCRIPTION
- main.py: rename `to` → `recipient` in WS handler for clarity
- api/a2a.py: use `typing.Union[dict, str]` for broader Python compatibility

No functional change; improves readability and compatibility.